### PR TITLE
fix std.error calculation in rmedsem.lavaan

### DIFF
--- a/R/rmedsem_lavaan.R
+++ b/R/rmedsem_lavaan.R
@@ -100,7 +100,7 @@ rmedsem.lavaan <- function(mod, indep, med, dep, standardized=TRUE, mcreps=NULL,
   delta_lci <- prodterm - ci.width*delta_se
   delta_uci <- prodterm + ci.width*delta_se
 
-  sigma <- matrix(c(var_moi, covmoidom, covmoidom, var_dom), nrow=2, ncol=2, byrow = F)
+  sigma <- matrix(c(var_moi, covmoidom, covmoidom, var_dom), nrow=2, ncol=2)
   coefx <- mvtnorm::rmvnorm(n=mcreps, mean=c(coef_moi, coef_dom), sigma = sigma)
   prod_coef <- apply(coefx, 1, prod)
   montc_prod <- mean(prod_coef)
@@ -117,7 +117,7 @@ rmedsem.lavaan <- function(mod, indep, med, dep, standardized=TRUE, mcreps=NULL,
   coef_tot <- coef_doi + prodterm
   sigma <- matrix(c(var_moi, covmoidom, covmoidoi,
                     covmoidom, var_dom, covdomdoi,
-                    covmoidoi, covdomdoi, var_doi), nrow=3, ncol=3, byrow = F)
+                    covmoidoi, covdomdoi, var_doi), nrow=3, ncol=3)
   coefx <- mvtnorm::rmvnorm(n=mcreps, mean=c(coef_moi, coef_dom, coef_doi), sigma = sigma)
   tot_eff_samp <- (coefx[,1]*coefx[,2])+coefx[,3]
   coef_tot <- mean(tot_eff_samp)

--- a/R/rmedsem_lavaan.R
+++ b/R/rmedsem_lavaan.R
@@ -29,31 +29,35 @@
 #' print(out)
 #'
 rmedsem.lavaan <- function(mod, indep, med, dep, standardized=TRUE, mcreps=NULL,
-                           approach=c("bk", "zlc"), p.threshold=0.05,
+                           approach=c("bk", "zlc"), p.threshold=0.05, ci.two.tailed=0.95,
                            effect.size=c("RIT","RID")){
+  ci.width <- qnorm(1-(1-ci.two.tailed)/2)
+
   # for testing
-  #indep="math"; med="read"; dep="science";
-  #indep="SES"; med="Alien67"; dep="Alien71";
-  #indep="ind60"; med="dem60"; dep="dem65"
+  # indep="math"; med="read"; dep="science";
+  # indep="SES"; med="Alien67"; dep="Alien71";
+  # indep="ind60"; med="dem60"; dep="dem65"
   N <- lavaan::nobs(mod)
-  if(is.null(mcreps) || mcreps < N){
+  if (is.null(mcreps) || mcreps < N){
     mcreps=N
   }
 
-  V <- lavaan::vcov(mod)
   moi <- sprintf("%s~%s", med, indep)
   dom <- sprintf("%s~%s", dep, med)
   doi <- sprintf("%s~%s", dep, indep)
-  corrmoidom = abs(V[moi,dom])
-  corrmoidoi = abs(V[moi,doi])
-  corrdomdoi = abs(V[dom,doi])
 
   if(standardized){
+    V <- lavaan::lavInspect(mod, what="vcov.std.all")
     coefs <- lavaan::standardizedsolution(mod)
     coefs$est <- coefs$est.std
   } else {
+    V <- lavaan::vcov(mod)
     coefs <- lavaan::parameterEstimates(mod)
   }
+  
+  covmoidom = V[moi,dom]
+  covmoidoi = V[moi,doi]
+  covdomdoi = V[dom,doi]
 
   # IV -> M
   coef_moi <- with(coefs, est[lhs==med & rhs==indep])
@@ -72,32 +76,32 @@ rmedsem.lavaan <- function(mod, indep, med, dep, standardized=TRUE, mcreps=NULL,
   se_doi   <- with(coefs, se[lhs==dep & rhs==indep])
   var_doi  <- se_doi^2
   pval_doi <- with(coefs, pvalue[lhs==dep & rhs==indep])
-  lci_doi <- coef_doi - 1.959964*se_doi
-  uci_doi <- coef_doi + 1.959964*se_doi
+  lci_doi <- coef_doi - ci.width*se_doi
+  uci_doi <- coef_doi + ci.width*se_doi
 
   prodterm <- coef_moi * coef_dom
 
   sobel_se  <- sqrt((coef_dom^2)*var_moi + (coef_moi^2)*var_dom)
   sobel_z   <- prodterm/sobel_se
   sobel_pv  <- 2*(1-stats::pnorm(abs(sobel_z)))
-  sobel_lci <- prodterm - 1.959964*sobel_se
-  sobel_uci <- prodterm + 1.959964*sobel_se
+  sobel_lci <- prodterm - ci.width*sobel_se
+  sobel_uci <- prodterm + ci.width*sobel_se
 
   # here I use normal theory confidence limits, however according
   # to MacKinnon on page 97, these may not always be precise, however
   # in the DELTA METHOD below, it seems like normaly theory limits
-  # are used there as well, that is 1.959964 is used
+  # are used there as well, that is ci.width is used
 
   #delta_se <- sqrt( (coef_dom^2)*var_moi + (coef_moi^2)*var_dom + (var_moi*var_dom) )
-  delta_se <- sqrt( (coef_dom^2)*var_moi + (coef_moi^2)*var_dom + 2*coef_dom*coef_moi*corrmoidom )
+  delta_se <- sqrt( (coef_dom^2)*var_moi + (coef_moi^2)*var_dom + 2*coef_dom*coef_moi*covmoidom )
 
   delta_z  <- prodterm/delta_se
   delta_pv  <- 2*(1-stats::pnorm(abs(delta_z)))
-  delta_lci <- prodterm - 1.959964*delta_se
-  delta_uci <- prodterm + 1.959964*delta_se
+  delta_lci <- prodterm - ci.width*delta_se
+  delta_uci <- prodterm + ci.width*delta_se
 
-  sigma <- matrix(c(se_moi, corrmoidom, corrmoidom, se_dom), nrow=2, ncol=2, byrow = F)
-  coefx <- mvtnorm::rmvnorm(n=mcreps, mean=c(coef_moi, coef_dom), sigma = sigma**2)
+  sigma <- matrix(c(var_moi, covmoidom, covmoidom, var_dom), nrow=2, ncol=2, byrow = F)
+  coefx <- mvtnorm::rmvnorm(n=mcreps, mean=c(coef_moi, coef_dom), sigma = sigma)
   prod_coef <- apply(coefx, 1, prod)
   montc_prod <- mean(prod_coef)
   montc_se   <- stats::sd(prod_coef)
@@ -111,10 +115,10 @@ rmedsem.lavaan <- function(mod, indep, med, dep, standardized=TRUE, mcreps=NULL,
 
   # TE = IND + DE
   coef_tot <- coef_doi + prodterm
-  sigma <- matrix(c(se_moi, corrmoidom, corrmoidoi,
-                    corrmoidom, se_dom, corrdomdoi,
-                    corrmoidoi, corrdomdoi, se_doi), nrow=3, ncol=3, byrow = F)
-  coefx <- mvtnorm::rmvnorm(n=mcreps, mean=c(coef_moi, coef_dom, coef_doi), sigma = sigma**2)
+  sigma <- matrix(c(var_moi, covmoidom, covmoidoi,
+                    covmoidom, var_dom, covdomdoi,
+                    covmoidoi, covdomdoi, var_doi), nrow=3, ncol=3, byrow = F)
+  coefx <- mvtnorm::rmvnorm(n=mcreps, mean=c(coef_moi, coef_dom, coef_doi), sigma = sigma)
   tot_eff_samp <- (coefx[,1]*coefx[,2])+coefx[,3]
   coef_tot <- mean(tot_eff_samp)
   se_tot <- stats::sd(tot_eff_samp)


### PR DESCRIPTION
Fixed calculation of standard errors based on #3 

Firstly we get a covariance matrix of the standardized parameters when `rmedsem.lavaan(standardized=TRUE)`, using `lavaan::lavInspect(mod, what="vcov.std.all")`:

```r
# V <- lavaan::vcov(mod)

...

if (standardized) {
  V <- lavaan::lavInspect(mod, what="vcov.std.all")
  coefs <- lavaan::standardizedsolution(mod)
  coefs$est <- coefs$est.std
} else {
  V <- lavaan::vcov(mod)
  coefs <- lavaan::parameterEstimates(mod)
}
```

We no longer take the absolute values of the parameter covariances, and variables are renamed from `corrmoidom`, `corrmoidoi`, `corrdomdoi`, to ` covmoidom`, `covmoidoi`, `covdomdoi`, in order to avoid confusion (as they are not correlations).

```r
# corrmoidom = abs(V[moi,dom])
# corrmoidoi = abs(V[moi,doi])
# corrdomdoi = abs(V[dom,doi])
covmoidom = V[moi,dom] 
covmoidoi = V[moi,doi]
covdomdoi = V[dom,doi]
```

Instead of using standard errors alongside covariances when creating `sigma` we now only use variances and covariances. Since `sigma` is symmetric, I also removed `byrow = F`, since it makes no difference.

```r
# sigma <- matrix(c(var_moi, corrmoidom, corrmoidom, var_dom), nrow=2, ncol=2, byrow=F)
sigma <- matrix(c(var_moi, covmoidom, covmoidom, var_dom), nrow=2, ncol=2)

...

# sigma <- matrix(c(se_moi, corrmoidom, corrmoidoi,
#                   corrmoidom, se_dom, corrdomdoi,
#                   corrmoidoi, corrdomdoi, se_doi), nrow=3, ncol=3, byrow=F)
sigma <- matrix(c(var_moi, covmoidom, covmoidoi,
                  covmoidom, var_dom, covdomdoi,
                  covmoidoi, covdomdoi, var_doi), nrow=3, ncol=3)
```

Since we now use variances in the diagonals of `sigma` we also no longer square `sigma`.

```r
# coefx <- mvtnorm::rmvnorm(n=mcreps, mean=c(coef_moi, coef_dom), sigma = sigma**2)
coefx <- mvtnorm::rmvnorm(n=mcreps, mean=c(coef_moi, coef_dom), sigma = sigma)

...

# coefx <- mvtnorm::rmvnorm(n=mcreps, mean=c(coef_moi, coef_dom, coef_doi), sigma = sigma**2)
coefx <- mvtnorm::rmvnorm(n=mcreps, mean=c(coef_moi, coef_dom, coef_doi), sigma = sigma)
```

Additionally I replaced occurences of `1.959964` with `ci.width`, which is calculated based on the function argument `ci.two.tailed`, which has a default value of `0.95`.

```r
rmedsem.lavaan <- function(..., ci.two.tailed=0.95) {
  ci.width <- qnorm(1-(1-ci.two.tailed)/2)

  ...

  # lci_doi <- coef_doi - 1.959964*se_doi
  # uci_doi <- coef_doi + 1.959964*se_doi
  lci_doi <- coef_doi - ci.width*se_doi
  uci_doi <- coef_doi + ci.width*se_doi

  ...
}
```
